### PR TITLE
Urgent Hotfix: updating composer-plugin-api to fix breaking builds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,6 @@
 	},
 	"require": {
 		"php": ">=5.3.6",
-		"composer-plugin-api": "1.0.0"
+		"composer-plugin-api": "^1.0"
 	}
 }


### PR DESCRIPTION
As people are updating to composer v1.1.0, builds are breaking in a lot of places. This fixes all Pattern Lab related build errors. I'm not sure if this plugin is needed, but anyway, this fixes it. The error I'm seeing is:

```
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - Installation request for pattern-lab/unified-asset-installer v0.5.5 -> satisfiable by pattern-lab/unified-asset-installer[v0.5.5].
    - pattern-lab/unified-asset-installer v0.5.5 requires composer-plugin-api 1.0.0 -> no matching package found.
  Problem 2
    - pattern-lab/unified-asset-installer v0.5.5 requires composer-plugin-api 1.0.0 -> no matching package found.
    - pattern-lab/core v0.7.2 requires pattern-lab/unified-asset-installer ~0.5 -> satisfiable by pattern-lab/unified-asset-installer[v0.5.5].
    - Installation request for pattern-lab/core v0.7.2 -> satisfiable by pattern-lab/core[v0.7.2].
Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.
```

Related threads:

- https://github.com/composer/composer/issues/5252#issuecomment-215565451
- https://github.com/phpDocumentor/UnifiedAssetInstaller/pull/10